### PR TITLE
typo in colourname

### DIFF
--- a/R/plot_hit_grid.R
+++ b/R/plot_hit_grid.R
@@ -51,7 +51,7 @@ plot_hit_grid <- function(m, filename, transect.length, max.ht, max.vai) {
   vai.label =  expression(paste(VAI~(m^2 ~m^-2)))
   ggplot2::ggplot(m, ggplot2::aes(x = xbin, y = zbin))+
     ggplot2::geom_tile(ggplot2::aes(fill = vai))+
-    ggplot2::scale_fill_gradient(low="gray88", high="dark green",
+    ggplot2::scale_fill_gradient(low="gray88", high="darkgreen",
                                  na.value = "white",
                                  limits=c(0, max.vai),
                                  name=vai.label)+

--- a/R/process_multi_pcl.R
+++ b/R/process_multi_pcl.R
@@ -158,7 +158,7 @@ process_multi_pcl <- function(data_dir, user_height, marker.spacing, max.vai, pa
 
       hit.grid <- ggplot2::ggplot(m6, ggplot2::aes(x = xbin, y = zbin))+
         ggplot2::geom_tile(ggplot2::aes(fill = vai))+
-        ggplot2::scale_fill_gradient(low="gray88", high="dark green",
+        ggplot2::scale_fill_gradient(low="gray88", high="darkgreen",
                                      na.value = "white",
                                      limits=c(0, 8),
                                      name=vai.label)+

--- a/R/process_pcl.R
+++ b/R/process_pcl.R
@@ -178,7 +178,7 @@ process_pcl<- function(f, user_height, marker.spacing, max.vai, pavd = FALSE, hi
   #x11(width = 8, height = 6)
   hit.grid <- ggplot2::ggplot(m6, ggplot2::aes(x = xbin, y = zbin))+
     ggplot2::geom_tile(ggplot2::aes(fill = vai))+
-    ggplot2::scale_fill_gradient(low="gray88", high="dark green",
+    ggplot2::scale_fill_gradient(low="gray88", high="darkgreen",
                                  na.value = "white",
                                  limits=c(0, 8),
                                  name=vai.label)+

--- a/R/process_tls.R
+++ b/R/process_tls.R
@@ -120,7 +120,7 @@ process_tls<- function(f, slice, pavd = FALSE, hist = FALSE){
   #x11(width = 8, height = 6)
   hit.grid <- ggplot2::ggplot(m6, ggplot2::aes(x = xbin, y = zbin))+
     ggplot2::geom_tile(ggplot2::aes(fill = vai))+
-    ggplot2::scale_fill_gradient(low="gray88", high="dark green",
+    ggplot2::scale_fill_gradient(low="gray88", high="darkgreen",
                                  na.value = "white",
                                  limits=c(0, 8),
                                  name=vai.label)+


### PR DESCRIPTION
Apparently something in the latest version (1.1.0) of the "scales" package now doesn't like the two-word version.